### PR TITLE
JG-7 Añadi separadores visuales entre secciones de contenido

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,30 @@
             line-height: 1.6;
         }
 
+        /* SEPARADORES VISUALES ENTRE SECCIONES */
         .stats {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             gap: 20px;
             margin: 30px 0;
+            border-top: 2px solid #e0e0e0;
+            padding-top: 30px;
+        }
+
+        /* Separador entre stats y botones */
+        .stats + div[style] {
+            border-top: 2px solid #e0e0e0;
+            margin-top: 30px;
+            padding-top: 20px;
+        }
+
+        /* Separador entre botones y contenido dinámico */
+        #dynamic-content {
+            border-top: 2px solid #e0e0e0;
+            margin-top: 30px;
+            padding-top: 20px;
+            min-height: 60px;
+            transition: background 0.3s;
         }
 
         .stat-box {


### PR DESCRIPTION
 Se agregó líneas divisorias o mayor espaciado visual entre las secciones de estadísticas, botones interactivos y el contenido dinámico.
![image](https://github.com/user-attachments/assets/fda6bb90-2cec-4053-b4a6-acb848184419)
